### PR TITLE
Graceful cancellation

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "cake.tool": {
-      "version": "2.0.0",
+      "version": "2.2.0",
       "commands": [
         "dotnet-cake"
       ]

--- a/build/version.json
+++ b/build/version.json
@@ -1,6 +1,6 @@
 {
   "Major": 8,
-  "Minor": 1,
+  "Minor": 2,
   "Patch": 0,
   "PreRelease": ""
 }

--- a/src/IntelligentPlant.BackgroundTasks/BackgroundTaskService.cs
+++ b/src/IntelligentPlant.BackgroundTasks/BackgroundTaskService.cs
@@ -297,6 +297,14 @@ namespace IntelligentPlant.BackgroundTasks {
                     }
                     OnCompleted(workItem, _stopwatch.Elapsed - elapsedBefore);
                 }
+                catch (OperationCanceledException e) {
+                    if (cancellationToken.IsCancellationRequested) {
+                        OnCompleted(workItem, _stopwatch.Elapsed - elapsedBefore);
+                    }
+                    else {
+                        OnError(workItem, e, _stopwatch.Elapsed - elapsedBefore);
+                    }
+                }
                 catch (Exception e) {
                     OnError(workItem, e, _stopwatch.Elapsed - elapsedBefore);
                 }


### PR DESCRIPTION
This PR changes the behaviour of cancelled work items so that they are now considered to have completed successfully, provided that the cancellation token for the work item has requested cancellation.

If an `OperationCanceledException` is thrown downstream but the work item's cancellation token has not requested cancellation, the work item will be considered to have completed with an error as before.