### PR TITLE
v10.0.0

### DIFF
--- a/build/version.json
+++ b/build/version.json
@@ -1,6 +1,6 @@
 {
-  "Major": 9,
-  "Minor": 1,
+  "Major": 10,
+  "Minor": 0,
   "Patch": 0,
   "PreRelease": ""
 }

--- a/examples/ExampleAspNetApp/ExampleAspNetApp.csproj
+++ b/examples/ExampleAspNetApp/ExampleAspNetApp.csproj
@@ -100,34 +100,34 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNet.WebApi">
-      <Version>5.2.7</Version>
+      <Version>5.2.9</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.AspNet.WebApi.Client">
-      <Version>5.2.7</Version>
+      <Version>5.2.9</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.AspNet.WebApi.Core">
-      <Version>5.2.7</Version>
+      <Version>5.2.9</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.AspNet.WebApi.WebHost">
-      <Version>5.2.7</Version>
+      <Version>5.2.9</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform">
-      <Version>3.6.0</Version>
+      <Version>4.1.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection">
-      <Version>5.0.1</Version>
+      <Version>7.0.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Logging">
-      <Version>5.0.0</Version>
+      <Version>7.0.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Logging.Console">
-      <Version>5.0.0</Version>
+      <Version>7.0.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Logging.Debug">
-      <Version>5.0.0</Version>
+      <Version>7.0.0</Version>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
-      <Version>13.0.2</Version>
+      <Version>13.0.3</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/examples/ExampleAspNetApp/Web.config
+++ b/examples/ExampleAspNetApp/Web.config
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <!--
   For more information on how to configure your ASP.NET application, please visit
   https://go.microsoft.com/fwlink/?LinkId=301879
@@ -6,55 +6,61 @@
 <configuration>
   <appSettings></appSettings>
   <system.web>
-    <compilation debug="true" targetFramework="4.8"/>
-    <httpRuntime targetFramework="4.8"/>
+    <compilation debug="true" targetFramework="4.8" />
+    <httpRuntime targetFramework="4.8" />
   </system.web>
   <system.webServer>
     <handlers>
-      <remove name="ExtensionlessUrlHandler-Integrated-4.0"/>
-      <remove name="OPTIONSVerbHandler"/>
-      <remove name="TRACEVerbHandler"/>
-      <add name="ExtensionlessUrlHandler-Integrated-4.0" path="*." verb="*" type="System.Web.Handlers.TransferRequestHandler" preCondition="integratedMode,runtimeVersionv4.0"/>
+      <remove name="ExtensionlessUrlHandler-Integrated-4.0" />
+      <remove name="OPTIONSVerbHandler" />
+      <remove name="TRACEVerbHandler" />
+      <add name="ExtensionlessUrlHandler-Integrated-4.0" path="*." verb="*" type="System.Web.Handlers.TransferRequestHandler" preCondition="integratedMode,runtimeVersionv4.0" />
     </handlers>
   </system.webServer>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-			<dependentAssembly>
-				<assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0"/>
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-5.0.0.1" newVersion="5.0.0.1"/>
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30AD4FE6B2A6AEED" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0"/>
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Extensions.Logging.Abstractions" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0"/>
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Extensions.DependencyInjection" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-5.0.0.1" newVersion="5.0.0.1"/>
-			</dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed"/>
-        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0"/>
+        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="B03F5F7F11D50A3A" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Web.Helpers" publicKeyToken="31bf3856ad364e35"/>
-        <bindingRedirect oldVersion="0.0.0.0-3.0.0.0" newVersion="3.0.0.0"/>
+        <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.0.0.1" newVersion="5.0.0.1" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Web.Mvc" publicKeyToken="31bf3856ad364e35"/>
-        <bindingRedirect oldVersion="0.0.0.0-5.2.7.0" newVersion="5.2.7.0"/>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30AD4FE6B2A6AEED" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Web.WebPages" publicKeyToken="31bf3856ad364e35"/>
-        <bindingRedirect oldVersion="0.0.0.0-3.0.0.0" newVersion="3.0.0.0"/>
+        <assemblyIdentity name="Microsoft.Extensions.Logging.Abstractions" publicKeyToken="ADB9793829DDAE60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Extensions.DependencyInjection" publicKeyToken="ADB9793829DDAE60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.0.0.1" newVersion="5.0.0.1" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" />
+        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Web.Helpers" publicKeyToken="31bf3856ad364e35" />
+        <bindingRedirect oldVersion="0.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Web.Mvc" publicKeyToken="31bf3856ad364e35" />
+        <bindingRedirect oldVersion="0.0.0.0-5.2.7.0" newVersion="5.2.7.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Web.WebPages" publicKeyToken="31bf3856ad364e35" />
+        <bindingRedirect oldVersion="0.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
+  <system.codedom>
+    <compilers>
+      <compiler language="c#;cs;csharp" extension=".cs" warningLevel="4" compilerOptions="/langversion:default /nowarn:1659;1699;1701;612;618" type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.CSharpCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=4.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
+      <compiler language="vb;vbs;visualbasic;vbscript" extension=".vb" warningLevel="4" compilerOptions="/langversion:default /nowarn:41008,40000,40008 /define:_MYTYPE=\&quot;Web\&quot; /optionInfer+" type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.VBCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=4.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
+    </compilers>
+  </system.codedom>
 </configuration>

--- a/examples/IntelligentPlant.BackgroundTasks.ExampleApp/Controllers/TasksController.cs
+++ b/examples/IntelligentPlant.BackgroundTasks.ExampleApp/Controllers/TasksController.cs
@@ -31,7 +31,7 @@ namespace IntelligentPlant.BackgroundTasks.ExampleApp.Controllers {
         public async Task<string> CreateTask(CancellationToken cancellationToken) {
             var tcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
 
-            var taskId = _backgroundTaskService.QueueBackgroundWorkItem(
+            var workItem = _backgroundTaskService.QueueBackgroundWorkItem(
                 ct => {
                     using (s_activitySource.StartActivity(GetType().FullName + "/" + nameof(CreateTask))) {
                         try {
@@ -50,7 +50,7 @@ namespace IntelligentPlant.BackgroundTasks.ExampleApp.Controllers {
             );
 
             await tcs.Task.ConfigureAwait(false);
-            return taskId;
+            return workItem.Id;
         }
     }
 }

--- a/examples/IntelligentPlant.BackgroundTasks.ExampleApp/IntelligentPlant.BackgroundTasks.ExampleApp.csproj
+++ b/examples/IntelligentPlant.BackgroundTasks.ExampleApp/IntelligentPlant.BackgroundTasks.ExampleApp.csproj
@@ -1,16 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <IsSignable>false</IsSignable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenTelemetry" Version="1.2.0-rc1" />
-    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.2.0-rc1" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.0.0-rc8" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc8" />
+    <PackageReference Include="OpenTelemetry" Version="1.6.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.6.0" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.6.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.5.1-beta.1" />
   </ItemGroup>
   
   <ItemGroup>

--- a/src/IntelligentPlant.BackgroundTasks.DependencyInjection/IntelligentPlant.BackgroundTasks.DependencyInjection.csproj
+++ b/src/IntelligentPlant.BackgroundTasks.DependencyInjection/IntelligentPlant.BackgroundTasks.DependencyInjection.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="1.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/IntelligentPlant.BackgroundTasks.OpenTelemetry/IntelligentPlant.BackgroundTasks.OpenTelemetry.csproj
+++ b/src/IntelligentPlant.BackgroundTasks.OpenTelemetry/IntelligentPlant.BackgroundTasks.OpenTelemetry.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenTelemetry.Api" Version="1.5.1" />
+    <PackageReference Include="OpenTelemetry.Api" Version="1.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/IntelligentPlant.BackgroundTasks/BackgroundTaskServiceExtensions.cs
+++ b/src/IntelligentPlant.BackgroundTasks/BackgroundTaskServiceExtensions.cs
@@ -30,7 +30,7 @@ namespace IntelligentPlant.BackgroundTasks {
         ///   the work item thread immediately before the item is run.
         /// </param>
         /// <returns>
-        ///   The unique identifier for the queued work item.
+        ///   A <see cref="BackgroundWorkItem"/> that represents the queued work item.
         /// </returns>
         /// <exception cref="ArgumentNullException">
         ///   <paramref name="backgroundTaskService"/> is <see langword="null"/>.
@@ -38,7 +38,7 @@ namespace IntelligentPlant.BackgroundTasks {
         /// <exception cref="ArgumentNullException">
         ///   <paramref name="workItem"/> is <see langword="null"/>.
         /// </exception>
-        public static string QueueBackgroundWorkItem(
+        public static BackgroundWorkItem QueueBackgroundWorkItem(
             this IBackgroundTaskService backgroundTaskService,
             Action<CancellationToken> workItem,
             string? displayName = null,
@@ -54,53 +54,7 @@ namespace IntelligentPlant.BackgroundTasks {
             var item = new BackgroundWorkItem(workItem, displayName, captureParentActivity);
             backgroundTaskService.QueueBackgroundWorkItem(item);
 
-            return item.Id;
-        }
-
-
-        /// <summary>
-        /// Adds an asynchronous work item to the queue.
-        /// </summary>
-        /// <param name="backgroundTaskService">
-        ///   The <see cref="IBackgroundTaskService"/>.
-        /// </param>
-        /// <param name="workItem">
-        ///   The work item.
-        /// </param>
-        /// <param name="displayName">
-        ///   The display name for the work item.
-        /// </param>
-        /// <param name="captureParentActivity">
-        ///   When <see langword="true"/>, the value of <see cref="Activity.Current"/> at the 
-        ///   moment that the <see cref="BackgroundWorkItem"/> is created will be restored onto 
-        ///   the work item thread immediately before the item is run.
-        /// </param>
-        /// <returns>
-        ///   The unique identifier for the queued work item.
-        /// </returns>
-        /// <exception cref="ArgumentNullException">
-        ///   <paramref name="backgroundTaskService"/> is <see langword="null"/>.
-        /// </exception>
-        /// <exception cref="ArgumentNullException">
-        ///   <paramref name="workItem"/> is <see langword="null"/>.
-        /// </exception>
-        public static string QueueBackgroundWorkItem(
-            this IBackgroundTaskService backgroundTaskService,
-            Func<CancellationToken, Task> workItem,
-            string? displayName = null,
-            bool captureParentActivity = false
-        ) {
-            if (backgroundTaskService == null) {
-                throw new ArgumentNullException(nameof(backgroundTaskService));
-            }
-            if (workItem == null) {
-                throw new ArgumentNullException(nameof(workItem));
-            }
-
-            var item = new BackgroundWorkItem(workItem, displayName, captureParentActivity);
-            backgroundTaskService.QueueBackgroundWorkItem(item);
-
-            return item.Id;
+            return item;
         }
 
 
@@ -127,7 +81,7 @@ namespace IntelligentPlant.BackgroundTasks {
         ///   be passed to <paramref name="workItem"/>.
         /// </param>
         /// <returns>
-        ///   The unique identifier for the queued work item.
+        ///   A <see cref="BackgroundWorkItem"/> that represents the queued work item.
         /// </returns>
         /// <exception cref="ArgumentNullException">
         ///   <paramref name="backgroundTaskService"/> is <see langword="null"/>.
@@ -135,7 +89,7 @@ namespace IntelligentPlant.BackgroundTasks {
         /// <exception cref="ArgumentNullException">
         ///   <paramref name="workItem"/> is <see langword="null"/>.
         /// </exception>
-        public static string QueueBackgroundWorkItem(
+        public static BackgroundWorkItem QueueBackgroundWorkItem(
             this IBackgroundTaskService backgroundTaskService,
             Action<CancellationToken> workItem,
             string? displayName,
@@ -164,7 +118,7 @@ namespace IntelligentPlant.BackgroundTasks {
         ///   be passed to <paramref name="workItem"/>.
         /// </param>
         /// <returns>
-        ///   The unique identifier for the queued work item.
+        ///   A <see cref="BackgroundWorkItem"/> that represents the queued work item.
         /// </returns>
         /// <exception cref="ArgumentNullException">
         ///   <paramref name="backgroundTaskService"/> is <see langword="null"/>.
@@ -172,7 +126,7 @@ namespace IntelligentPlant.BackgroundTasks {
         /// <exception cref="ArgumentNullException">
         ///   <paramref name="workItem"/> is <see langword="null"/>.
         /// </exception>
-        public static string QueueBackgroundWorkItem(
+        public static BackgroundWorkItem QueueBackgroundWorkItem(
             this IBackgroundTaskService backgroundTaskService,
             Action<CancellationToken> workItem,
             string? displayName,
@@ -197,7 +151,7 @@ namespace IntelligentPlant.BackgroundTasks {
         ///   be passed to <paramref name="workItem"/>.
         /// </param>
         /// <returns>
-        ///   The unique identifier for the queued work item.
+        ///   A <see cref="BackgroundWorkItem"/> that represents the queued work item.
         /// </returns>
         /// <exception cref="ArgumentNullException">
         ///   <paramref name="backgroundTaskService"/> is <see langword="null"/>.
@@ -205,7 +159,7 @@ namespace IntelligentPlant.BackgroundTasks {
         /// <exception cref="ArgumentNullException">
         ///   <paramref name="workItem"/> is <see langword="null"/>.
         /// </exception>
-        public static string QueueBackgroundWorkItem(
+        public static BackgroundWorkItem QueueBackgroundWorkItem(
             this IBackgroundTaskService backgroundTaskService,
             Action<CancellationToken> workItem,
             params CancellationToken[] tokens
@@ -237,7 +191,7 @@ namespace IntelligentPlant.BackgroundTasks {
         ///   be passed to <paramref name="workItem"/>.
         /// </param>
         /// <returns>
-        ///   The unique identifier for the queued work item.
+        ///   A <see cref="BackgroundWorkItem"/> that represents the queued work item.
         /// </returns>
         /// <exception cref="ArgumentNullException">
         ///   <paramref name="backgroundTaskService"/> is <see langword="null"/>.
@@ -245,7 +199,7 @@ namespace IntelligentPlant.BackgroundTasks {
         /// <exception cref="ArgumentNullException">
         ///   <paramref name="workItem"/> is <see langword="null"/>.
         /// </exception>
-        public static string QueueBackgroundWorkItem(
+        public static BackgroundWorkItem QueueBackgroundWorkItem(
             this IBackgroundTaskService backgroundTaskService,
             Action<CancellationToken> workItem,
             string? displayName,
@@ -294,13 +248,8 @@ namespace IntelligentPlant.BackgroundTasks {
         ///   moment that the <see cref="BackgroundWorkItem"/> is created will be restored onto 
         ///   the work item thread immediately before the item is run.
         /// </param>
-        /// <param name="tokens">
-        ///   Additional cancellation tokens for the operation. A composite token consisting of 
-        ///   these tokens and the lifetime token of the <see cref="IBackgroundTaskService"/> will 
-        ///   be passed to <paramref name="workItem"/>.
-        /// </param>
         /// <returns>
-        ///   The unique identifier for the queued work item.
+        ///   A <see cref="BackgroundWorkItem"/> that represents the queued work item.
         /// </returns>
         /// <exception cref="ArgumentNullException">
         ///   <paramref name="backgroundTaskService"/> is <see langword="null"/>.
@@ -308,7 +257,58 @@ namespace IntelligentPlant.BackgroundTasks {
         /// <exception cref="ArgumentNullException">
         ///   <paramref name="workItem"/> is <see langword="null"/>.
         /// </exception>
-        public static string QueueBackgroundWorkItem(
+        public static BackgroundWorkItem QueueBackgroundWorkItem(
+            this IBackgroundTaskService backgroundTaskService,
+            Func<CancellationToken, Task> workItem,
+            string? displayName = null,
+            bool captureParentActivity = false
+        ) {
+            if (backgroundTaskService == null) {
+                throw new ArgumentNullException(nameof(backgroundTaskService));
+            }
+            if (workItem == null) {
+                throw new ArgumentNullException(nameof(workItem));
+            }
+
+            var item = new BackgroundWorkItem(workItem, displayName, captureParentActivity);
+            backgroundTaskService.QueueBackgroundWorkItem(item);
+
+            return item;
+        }
+
+
+        /// <summary>
+        /// Adds an asynchronous work item to the queue.
+        /// </summary>
+        /// <param name="backgroundTaskService">
+        ///   The <see cref="IBackgroundTaskService"/>.
+        /// </param>
+        /// <param name="workItem">
+        ///   The work item.
+        /// </param>
+        /// <param name="displayName">
+        ///   The display name for the work item.
+        /// </param>
+        /// <param name="captureParentActivity">
+        ///   When <see langword="true"/>, the value of <see cref="Activity.Current"/> at the 
+        ///   moment that the <see cref="BackgroundWorkItem"/> is created will be restored onto 
+        ///   the work item thread immediately before the item is run.
+        /// </param>
+        /// <param name="tokens">
+        ///   Additional cancellation tokens for the operation. A composite token consisting of 
+        ///   these tokens and the lifetime token of the <see cref="IBackgroundTaskService"/> will 
+        ///   be passed to <paramref name="workItem"/>.
+        /// </param>
+        /// <returns>
+        ///   A <see cref="BackgroundWorkItem"/> that represents the queued work item.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="backgroundTaskService"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="workItem"/> is <see langword="null"/>.
+        /// </exception>
+        public static BackgroundWorkItem QueueBackgroundWorkItem(
             this IBackgroundTaskService backgroundTaskService,
             Func<CancellationToken, Task> workItem,
             string? displayName,
@@ -337,7 +337,7 @@ namespace IntelligentPlant.BackgroundTasks {
         ///   be passed to <paramref name="workItem"/>.
         /// </param>
         /// <returns>
-        ///   The unique identifier for the queued work item.
+        ///   A <see cref="BackgroundWorkItem"/> that represents the queued work item.
         /// </returns>
         /// <exception cref="ArgumentNullException">
         ///   <paramref name="backgroundTaskService"/> is <see langword="null"/>.
@@ -345,7 +345,7 @@ namespace IntelligentPlant.BackgroundTasks {
         /// <exception cref="ArgumentNullException">
         ///   <paramref name="workItem"/> is <see langword="null"/>.
         /// </exception>
-        public static string QueueBackgroundWorkItem(
+        public static BackgroundWorkItem QueueBackgroundWorkItem(
             this IBackgroundTaskService backgroundTaskService,
             Func<CancellationToken, Task> workItem,
             string? displayName,
@@ -370,7 +370,7 @@ namespace IntelligentPlant.BackgroundTasks {
         ///   be passed to <paramref name="workItem"/>.
         /// </param>
         /// <returns>
-        ///   The unique identifier for the queued work item.
+        ///   A <see cref="BackgroundWorkItem"/> that represents the queued work item.
         /// </returns>
         /// <exception cref="ArgumentNullException">
         ///   <paramref name="backgroundTaskService"/> is <see langword="null"/>.
@@ -378,7 +378,7 @@ namespace IntelligentPlant.BackgroundTasks {
         /// <exception cref="ArgumentNullException">
         ///   <paramref name="workItem"/> is <see langword="null"/>.
         /// </exception>
-        public static string QueueBackgroundWorkItem(
+        public static BackgroundWorkItem QueueBackgroundWorkItem(
             this IBackgroundTaskService backgroundTaskService,
             Func<CancellationToken, Task> workItem,
             params CancellationToken[] tokens
@@ -407,7 +407,7 @@ namespace IntelligentPlant.BackgroundTasks {
         ///   be passed to <paramref name="workItem"/>.
         /// </param>
         /// <returns>
-        ///   The unique identifier for the queued work item.
+        ///   A <see cref="BackgroundWorkItem"/> that represents the queued work item.
         /// </returns>
         /// <exception cref="ArgumentNullException">
         ///   <paramref name="backgroundTaskService"/> is <see langword="null"/>.
@@ -415,7 +415,7 @@ namespace IntelligentPlant.BackgroundTasks {
         /// <exception cref="ArgumentNullException">
         ///   <paramref name="workItem"/> is <see langword="null"/>.
         /// </exception>
-        public static string QueueBackgroundWorkItem(
+        public static BackgroundWorkItem QueueBackgroundWorkItem(
             this IBackgroundTaskService backgroundTaskService,
             Func<CancellationToken, Task> workItem,
             string? displayName,
@@ -441,11 +441,13 @@ namespace IntelligentPlant.BackgroundTasks {
             // original delegate provided to us, or the auto-generated description will reference 
             // this method instead of the original delegate.
 
-            return backgroundTaskService.QueueBackgroundWorkItem(async (ct) => {
+            Func<CancellationToken, Task> workItemWithTokens = async (ct) => {
                 using (var compositeTokenSource = CancellationTokenSource.CreateLinkedTokenSource(new[] { ct }.Concat(additionalTokens).ToArray())) {
                     await workItem(compositeTokenSource.Token).ConfigureAwait(false);
                 }
-            }, displayName, captureParentActivity);
+            };
+
+            return QueueBackgroundWorkItem(backgroundTaskService, workItemWithTokens, displayName, captureParentActivity);
         }
 
     }

--- a/src/IntelligentPlant.BackgroundTasks/BackgroundTaskServiceWrapper.cs
+++ b/src/IntelligentPlant.BackgroundTasks/BackgroundTaskServiceWrapper.cs
@@ -136,7 +136,7 @@ namespace IntelligentPlant.BackgroundTasks {
                     null, 
                     async ct => {
                         using (var ctSource = CancellationTokenSource.CreateLinkedTokenSource(new[] { ct }.Concat(tokens).ToArray())) {
-                            await workItem.WorkItemAsync.Invoke(ctSource.Token);
+                            await workItem.WorkItemAsync.Invoke(ctSource.Token).ConfigureAwait(false);
                         }
                     }, 
                     workItem.Id, 

--- a/src/IntelligentPlant.BackgroundTasks/BackgroundWorkItem.cs
+++ b/src/IntelligentPlant.BackgroundTasks/BackgroundWorkItem.cs
@@ -29,13 +29,13 @@ namespace IntelligentPlant.BackgroundTasks {
         /// The synchronous work item. The value will be <see langword="null"/> if an asynchronous 
         /// work item was enqueued.
         /// </summary>
-        public Action<CancellationToken>? WorkItem { get; }
+        internal Action<CancellationToken>? WorkItem { get; }
 
         /// <summary>
         /// The asynchronous work item. The value will be <see langword="null"/> if a synchronous 
         /// work item was enqueued.
         /// </summary>
-        public Func<CancellationToken, Task>? WorkItemAsync { get; }
+        internal Func<CancellationToken, Task>? WorkItemAsync { get; }
 
         /// <summary>
         /// A task completion source that is used to signal when the work item has finished.

--- a/src/IntelligentPlant.BackgroundTasks/Resources.Designer.cs
+++ b/src/IntelligentPlant.BackgroundTasks/Resources.Designer.cs
@@ -88,7 +88,7 @@ namespace IntelligentPlant.BackgroundTasks {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to {{ Id = &apos;{0}&apos;, Type = &apos;{1}&apos;, DisplayName = &apos;{2}&apos; }}.
+        ///   Looks up a localized string similar to {{ Id = &apos;{0}&apos;, Type = &apos;{1}&apos;, DisplayName = &apos;{2}&apos;, Status = &apos;{3}&apos; }}.
         /// </summary>
         internal static string BackgroundWorkItem_StringFormat {
             get {

--- a/src/IntelligentPlant.BackgroundTasks/Resources.resx
+++ b/src/IntelligentPlant.BackgroundTasks/Resources.resx
@@ -127,10 +127,11 @@
     <value>Undefined</value>
   </data>
   <data name="BackgroundWorkItem_StringFormat" xml:space="preserve">
-    <value>{{ Id = '{0}', Type = '{1}', DisplayName = '{2}' }}</value>
+    <value>{{ Id = '{0}', Type = '{1}', DisplayName = '{2}', Status = '{3}' }}</value>
     <comment>{0} - ID
 {1} - async/sync/undefined
-{2} - display name</comment>
+{2} - display name
+{3} - pending/completed/faulted/cancelled</comment>
   </data>
   <data name="Error_CannotRegisterWorkItemsWhileStopped" xml:space="preserve">
     <value>Work items cannot be enqueued while the service is stopped.</value>

--- a/tests/IntelligentPlant.BackgroundTasks.Tests/BackgroundTaskServiceWrapperTests.cs
+++ b/tests/IntelligentPlant.BackgroundTasks.Tests/BackgroundTaskServiceWrapperTests.cs
@@ -3,8 +3,6 @@ using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace IntelligentPlant.BackgroundTasks.Tests {

--- a/tests/IntelligentPlant.BackgroundTasks.Tests/IntelligentPlant.BackgroundTasks.Tests.csproj
+++ b/tests/IntelligentPlant.BackgroundTasks.Tests/IntelligentPlant.BackgroundTasks.Tests.csproj
@@ -13,12 +13,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.7" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.7" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
-    <PackageReference Include="coverlet.collector" Version="1.1.0">
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
This PR contains changes for v10.0.0 of the libraries.

**Breaking Changes:**
- All `QueueBackgroundWorkItem` extension methods now return `BackgroundWorkItem` instances instead of `string` identifiers for the work items.
- `BackgroundWorkItem.WorkItem` and `BackgroundWorkItem.WorkItemAsync` properties are now internal instead of public.

**Other Changes:**
- A new `BackgroundWorkItem.Task` property has been added. This task will complete when the work item completes, so it is now possible to register a background task and later wait for it to complete before continuing. This is useful in scenarios where e.g. you want a `Dispose` or `DisposeAsync` method to wait for the work item to complete before disposing of some resources used by the work item.
- Updates to package references such as OpenTelemetry and Microsoft.Extensions.DependencyInjection.