### PR TITLE
Explicit work item cancellation

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ services.AddAspNetCoreBackgroundTaskService(options => {
 
 Inject the [IBackgroundTaskService](./src/IntelligentPlant.BackgroundTasks/IBackgroundTaskService.cs) service into the class that you want to register the task from. Use one of the `QueueBackgroundWorkItem` overloads to enqueue the task:
 
-
 ```csharp
 public class EmailNotifier {
 
@@ -53,16 +52,64 @@ public class EmailNotifier {
 }
 ```
 
-By default, the `CancellationToken` provided to the work item will fire when the application is shutting down. The [BackgroundTaskServiceExtensions](./src/IntelligentPlant.BackgroundTasks/BackgroundTaskServiceExtensions.cs) class contains extension methods that allow you to specify additional `CancellationToken` instances for the work item. In these scenarios, a composite of the master token and all of the additional tokens is passed to the work item. Examples of when you might want to use this functionality include starting a long-running background task from an object that should stop when the object is disposed, e.g.
+The [BackgroundWorkItem](./src/IntelligentPlant.BackgroundTasks/BackgroundWorkItem.cs) type represents a work item that will run in a background task. All overloads of `QueueBackgroundWorkItem` (other than those that accept a `BackgroundWorkItem` instance) return a `BackgroundWorkItem` instance that represents the work item that has been queued. This can be used to cancel the work item or wait for it to complete if required. See the sections below for more information.
+
+> **IMPORTANT:** `BackgroundWorkItem` implements `IDisposable`. The background task service will automatically dispose of work items once they have completed. You may also manually dispose of work items if required.
+
+
+# Cancelling Background Tasks
+
+By default, the `CancellationToken` provided to the work item will fire when the application is shutting down. You can also explcitly or implicitly cancel work items using the methods described below.
+
+
+## Using `BackgroundWorkItem.Cancel()`
+
+The `BackgroundWorkItem` type defines a `Cancel` method that can be used to explicitly cancel the work item. For example:
 
 ```csharp
 public class MyClass : IDisposable {
+
+    private readonly BackgroundWorkItem _workItem;
+
+    public MyClass(IBackgroundTaskService backgroundTaskService) {
+        _workItem = backgroundTaskService.QueueBackgroundWorkItem(LongRunningTask);
+    }
+
+    private async Task LongRunningTask(CancellationToken cancellationToken) {
+        while (!cancellationToken.IsCancellationRequested) {
+            // Do long-running work.
+        }
+    }
+
+    public void Dispose() {
+        _workItem.Cancel();
+        _workItem.Dispose();
+    }
+
+}
+```
+
+Calling the `BackgroundWorkItem.Dispose` method will also cancel the work item if it has not already completed. Note however that calling `Dispose` will also immediately mark the work item's `Task` property as cancelled if it has not already completed. This means that if you are using the `Task` property to wait for the work item to complete (see below), you should not call `Dispose` and instead allow the background task service to dispose of the work item when it has completed.
+
+Cancelling a work item does not guarantee that the work item will stop executing immediately. The work item's delegate must react to the cancellation request and stop executing. Cancelling a work item that has already completed has no effect.
+
+> **IMPORTANT:** If a work item is explicitly cancelled before it has started executing, it will be removed from the queue and its delegate will not be executed. This is different to the behaviour of cancellation via `CancellationToken` instances (see below).
+
+
+## Using Additional `CancellationToken` Instances
+
+The [BackgroundTaskServiceExtensions](./src/IntelligentPlant.BackgroundTasks/BackgroundTaskServiceExtensions.cs) class defines `QueueBackgroundWorkItem` extension method overloads that allow you to specify additional `CancellationToken` instances for the work item. When registering a work item in this way, a composite of the master token and all of the additional tokens is passed to the work item. Examples of when you might want to use this functionality include starting a long-running background task from an object that should stop when the object is disposed. For example:
+
+```csharp
+public class MyClass : IDisposable {
+
+    private bool _disposed;
 
     private readonly CancellationTokenSource _shutdownSource = new CancellationTokenSource();
 
     public MyClass(IBackgroundTaskService backgroundTaskService) {
         backgroundTaskService.QueueBackgroundWorkItem(
-            LongRunningTask, 
+            LongRunningTask,
             _shutdownSource.Token
         );
     }
@@ -74,19 +121,25 @@ public class MyClass : IDisposable {
     }
 
     public void Dispose() {
+        if (_disposed) {
+            return;
+        }
         _shutdownSource.Cancel();
         _shutdownSource.Dispose();
+        _disposed = true;
     }
 
 }
 ```
+
+> **IMPORTANT:** If the composite cancellation token is triggered before the work item starts executing, the work item's delegate will still be called. It is the responsibility of the delegate to handle this scenario. This behaviour is different to the behaviour of cancellation via `BackgroundWorkItem.Cancel` (see above).
 
 
 # Waiting for Background Tasks to Complete
 
 ## Using `BackgroundWorkItem.Task`
 
-All `QueueBackgroundWorkItem` overloads return an instance of the [BackgroundWorkItem](./src/IntelligentPlant.BackgroundTasks/BackgroundWorkItem.cs) type. This type has a `Task` property that can be used to wait for the work item to complete. For example:
+The [BackgroundWorkItem](./src/IntelligentPlant.BackgroundTasks/BackgroundWorkItem.cs) type has a `Task` property that can be used to wait for the work item to complete. For example:
 
 ```csharp
 public class MyClass : IAsyncDisposable {
@@ -163,7 +216,8 @@ public class MyClass : IAsyncDisposable {
 }
 ```
 
-# EventSource
+
+# Event Source
 
 The `IntelligentPlant.BackgroundTasks` event source emits events when background work items are enqueued, dequeued, started, and completed. The `BackgroundTaskService.EventIds` class contains constants for the different event IDs that can be emitted. See [here](https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.tracing.eventsource) for more information about event sources.
 

--- a/build/version.json
+++ b/build/version.json
@@ -1,5 +1,5 @@
 {
-  "Major": 10,
+  "Major": 11,
   "Minor": 0,
   "Patch": 0,
   "PreRelease": ""

--- a/src/IntelligentPlant.BackgroundTasks/AssemblyAttributes.cs
+++ b/src/IntelligentPlant.BackgroundTasks/AssemblyAttributes.cs
@@ -1,0 +1,3 @@
+﻿using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("IntelligentPlant.BackgroundTasks.Tests")]

--- a/src/IntelligentPlant.BackgroundTasks/BackgroundTaskService.Log.cs
+++ b/src/IntelligentPlant.BackgroundTasks/BackgroundTaskService.Log.cs
@@ -26,7 +26,7 @@ namespace IntelligentPlant.BackgroundTasks {
         [LoggerMessage(EventIds.WorkItemFaulted, LogLevel.Trace, "Work item faulted: {workItem}", EventName = nameof(EventIds.WorkItemFaulted))]
         static partial void LogWorkItemFaulted(ILogger logger, BackgroundWorkItem workItem, Exception error);
 
-        [LoggerMessage(EventIds.ErrorInCallback, LogLevel.Error, "Error in callback '{callback}'. Callbacks should use try..catch blocks to prevent errors from propagating to the background task service.", EventName = nameof(EventIds.ErrorInCallback))]
+        [LoggerMessage(EventIds.ErrorInCallback, LogLevel.Error, "Error in callback or event handler '{callback}'. Handlers should use try..catch blocks to prevent errors from propagating to the background task service.", EventName = nameof(EventIds.ErrorInCallback))]
         static partial void LogErrorInCallback(ILogger logger, string callback, Exception error);
 
     }

--- a/src/IntelligentPlant.BackgroundTasks/BackgroundTaskService.cs
+++ b/src/IntelligentPlant.BackgroundTasks/BackgroundTaskService.cs
@@ -530,7 +530,7 @@ namespace IntelligentPlant.BackgroundTasks {
                 _disposedCancellationTokenSource.Dispose();
                 _queueSignal.Dispose();
                 while (_queue.TryDequeue(out var workItem)) {
-                    workItem.OnCompleted(new OperationCanceledException());
+                    workItem.Dispose();
                 }
             }
 

--- a/src/IntelligentPlant.BackgroundTasks/BackgroundTaskServiceWrapper.cs
+++ b/src/IntelligentPlant.BackgroundTasks/BackgroundTaskServiceWrapper.cs
@@ -34,6 +34,34 @@ namespace IntelligentPlant.BackgroundTasks {
         /// <inheritdoc/>
         public int QueuedItemCount => _isDisposed ? 0 : _inner.QueuedItemCount;
 
+        /// <inheritdoc/>
+        public event EventHandler<BackgroundWorkItem>? BeforeWorkItemStarted {
+            add {
+                if (!_isDisposed) {
+                    _inner.BeforeWorkItemStarted += value;
+                }
+            }
+            remove {
+                if (!_isDisposed) {
+                    _inner.BeforeWorkItemStarted -= value;
+                }
+            }
+        }
+
+        /// <inheritdoc/>
+        public event EventHandler<BackgroundWorkItem>? AfterWorkItemCompleted {
+            add {
+                if (!_isDisposed) {
+                    _inner.AfterWorkItemCompleted += value;
+                }
+            }
+            remove {
+                if (!_isDisposed) {
+                    _inner.AfterWorkItemCompleted -= value;
+                }
+            }
+        }
+
 
         /// <summary>
         /// Creates a new <see cref="BackgroundTaskServiceWrapper"/> object.

--- a/src/IntelligentPlant.BackgroundTasks/BackgroundWorkItem.cs
+++ b/src/IntelligentPlant.BackgroundTasks/BackgroundWorkItem.cs
@@ -268,6 +268,8 @@ namespace IntelligentPlant.BackgroundTasks {
             _cancellationTokenSource?.Cancel();
             _cancellationTokenSource?.Dispose();
 
+            OnCompleted(new OperationCanceledException());
+
             _disposed = true;
         }
 

--- a/src/IntelligentPlant.BackgroundTasks/BackgroundWorkItem.cs
+++ b/src/IntelligentPlant.BackgroundTasks/BackgroundWorkItem.cs
@@ -8,7 +8,17 @@ namespace IntelligentPlant.BackgroundTasks {
     /// <summary>
     /// Describes a work item that has been added to an <see cref="IBackgroundTaskService"/> queue.
     /// </summary>
-    public readonly struct BackgroundWorkItem : IEquatable<BackgroundWorkItem> {
+    public struct BackgroundWorkItem : IEquatable<BackgroundWorkItem>, IDisposable {
+
+        /// <summary>
+        /// Cancellation token used by the <see langword="default"/> value of this type.
+        /// </summary>
+        private static readonly CancellationToken s_cancelled = new CancellationToken(true);
+
+        /// <summary>
+        /// Specifies if the work item has been disposed.
+        /// </summary>
+        private bool _disposed;
 
         /// <summary>
         /// The parent activity for the background work item.
@@ -38,6 +48,16 @@ namespace IntelligentPlant.BackgroundTasks {
         internal Func<CancellationToken, Task>? WorkItemAsync { get; }
 
         /// <summary>
+        /// A cancellation token source that can be used to explicitly cancel the work item.
+        /// </summary>
+        private readonly CancellationTokenSource _cancellationTokenSource;
+
+        /// <summary>
+        /// A cancellation token that can be used to cancel the work item.
+        /// </summary>
+        internal CancellationToken CancellationToken => _cancellationTokenSource?.Token ?? s_cancelled;
+
+        /// <summary>
         /// A task completion source that is used to signal when the work item has finished.
         /// </summary>
         private readonly TaskCompletionSource<object?> _completionSource;
@@ -45,7 +65,7 @@ namespace IntelligentPlant.BackgroundTasks {
         /// <summary>
         /// A task that completes when the work item has finished executing.
         /// </summary>
-        public Task Task => _completionSource.Task;
+        public Task Task => _completionSource?.Task ?? Task.CompletedTask;
 
 
         /// <summary>
@@ -67,6 +87,7 @@ namespace IntelligentPlant.BackgroundTasks {
         ///   <paramref name="workItem"/> is <see langword="null"/>.
         /// </exception>
         public BackgroundWorkItem(Action<CancellationToken> workItem, string? displayName = null, bool captureParentActivity = false) {
+            _disposed = false;
             WorkItem = workItem ?? throw new ArgumentNullException(nameof(workItem));
             WorkItemAsync = null;
 
@@ -74,6 +95,7 @@ namespace IntelligentPlant.BackgroundTasks {
             Id = Guid.NewGuid().ToString();
             DisplayName = displayName;
             _completionSource = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+            _cancellationTokenSource = new CancellationTokenSource();
         }
 
 
@@ -96,6 +118,7 @@ namespace IntelligentPlant.BackgroundTasks {
         ///   <paramref name="workItem"/> is <see langword="null"/>.
         /// </exception>
         public BackgroundWorkItem(Func<CancellationToken, Task> workItem, string? displayName = null, bool captureParentActivity = false) {
+            _disposed = false;
             WorkItem = null;
             WorkItemAsync = workItem ?? throw new ArgumentNullException(nameof(workItem));
 
@@ -103,6 +126,7 @@ namespace IntelligentPlant.BackgroundTasks {
             Id = Guid.NewGuid().ToString();
             DisplayName = displayName;
             _completionSource = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+            _cancellationTokenSource = new CancellationTokenSource();
         }
 
 
@@ -131,6 +155,7 @@ namespace IntelligentPlant.BackgroundTasks {
             string? displayName,
             Activity? parentActivity
         ) {
+            _disposed = false;
             WorkItem = workItem;
             WorkItemAsync = workItemAsync;
 
@@ -138,6 +163,18 @@ namespace IntelligentPlant.BackgroundTasks {
             Id = id;
             DisplayName = displayName;
             _completionSource = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+            _cancellationTokenSource = new CancellationTokenSource();
+        }
+
+
+        /// <summary>
+        /// Cancels the work item.
+        /// </summary>
+        public void Cancel() {
+            if (_disposed) {
+                return;
+            }
+            _cancellationTokenSource?.Cancel();
         }
 
 
@@ -219,6 +256,19 @@ namespace IntelligentPlant.BackgroundTasks {
         /// <inheritdoc/>
         public static bool operator !=(BackgroundWorkItem left, BackgroundWorkItem right) {
             return !(left == right);
+        }
+
+
+        /// <inheritdoc/>
+        public void Dispose() {
+            if (_disposed) {
+                return;
+            }
+
+            _cancellationTokenSource?.Cancel();
+            _cancellationTokenSource?.Dispose();
+
+            _disposed = true;
         }
 
     }

--- a/src/IntelligentPlant.BackgroundTasks/IBackgroundTaskService.cs
+++ b/src/IntelligentPlant.BackgroundTasks/IBackgroundTaskService.cs
@@ -30,6 +30,16 @@ namespace IntelligentPlant.BackgroundTasks {
         /// </param>
         void QueueBackgroundWorkItem(BackgroundWorkItem workItem);
 
+        /// <summary>
+        /// Raised before a work item is started.
+        /// </summary>
+        event EventHandler<BackgroundWorkItem>? BeforeWorkItemStarted;
+
+        /// <summary>
+        /// Raised after a work item has completed.
+        /// </summary>
+        event EventHandler<BackgroundWorkItem>? AfterWorkItemCompleted;
+
     }
 
 }

--- a/tests/IntelligentPlant.BackgroundTasks.Tests/BackgroundTaskServiceTests.cs
+++ b/tests/IntelligentPlant.BackgroundTasks.Tests/BackgroundTaskServiceTests.cs
@@ -201,7 +201,7 @@ namespace IntelligentPlant.BackgroundTasks.Tests {
                 SampleUsingParentId = (ref ActivityCreationOptions<string> activityOptions) => ActivitySamplingResult.AllData,
                 Sample = (ref ActivityCreationOptions<ActivityContext> activityOptions) => ActivitySamplingResult.AllData
             })
-            using (var activitySource = new ActivitySource(TestContext.TestName))
+            using (var activitySource = new ActivitySource(TestContext.TestName!))
             using (var svc = ActivatorUtilities.CreateInstance<DefaultBackgroundTaskService>(s_serviceProvider, options))
             using (var semaphore = new SemaphoreSlim(0))
             using (var ctSource = new CancellationTokenSource()) {
@@ -209,7 +209,7 @@ namespace IntelligentPlant.BackgroundTasks.Tests {
 
                 using (var parentActivity = activitySource.StartActivity("Parent")) {
                     var workItem = svc.QueueBackgroundWorkItem(ct => {
-                        using (activitySource.StartActivity(TestContext.TestName)) {
+                        using (activitySource.StartActivity(TestContext.TestName!)) {
                             try {
                                 Assert.AreEqual(TestContext.TestName, Activity.Current?.DisplayName);
                                 Assert.AreEqual(parentActivity!.DisplayName, Activity.Current?.Parent?.DisplayName);
@@ -253,7 +253,7 @@ namespace IntelligentPlant.BackgroundTasks.Tests {
                 SampleUsingParentId = (ref ActivityCreationOptions<string> activityOptions) => ActivitySamplingResult.AllData,
                 Sample = (ref ActivityCreationOptions<ActivityContext> activityOptions) => ActivitySamplingResult.AllData
             })
-            using (var activitySource = new ActivitySource(TestContext.TestName))
+            using (var activitySource = new ActivitySource(TestContext.TestName!))
             using (var svc = ActivatorUtilities.CreateInstance<DefaultBackgroundTaskService>(s_serviceProvider, options))
             using (var semaphore = new SemaphoreSlim(0))
             using (var ctSource = new CancellationTokenSource()) {
@@ -261,7 +261,7 @@ namespace IntelligentPlant.BackgroundTasks.Tests {
 
                 using (var parentActivity = activitySource.StartActivity("Parent")) {
                     var workItem = svc.QueueBackgroundWorkItem(ct => {
-                        using (activitySource.StartActivity(TestContext.TestName)) {
+                        using (activitySource.StartActivity(TestContext.TestName!)) {
                             try {
                                 Assert.AreEqual(TestContext.TestName, Activity.Current?.DisplayName);
                                 Assert.AreNotEqual(parentActivity!.DisplayName, Activity.Current?.Parent?.DisplayName);
@@ -305,7 +305,7 @@ namespace IntelligentPlant.BackgroundTasks.Tests {
                 SampleUsingParentId = (ref ActivityCreationOptions<string> activityOptions) => ActivitySamplingResult.AllData,
                 Sample = (ref ActivityCreationOptions<ActivityContext> activityOptions) => ActivitySamplingResult.AllData
             })
-            using (var activitySource = new ActivitySource(TestContext.TestName))
+            using (var activitySource = new ActivitySource(TestContext.TestName!))
             using (var svc = ActivatorUtilities.CreateInstance<DefaultBackgroundTaskService>(s_serviceProvider, options))
             using (var semaphore = new SemaphoreSlim(0))
             using (var ctSource = new CancellationTokenSource()) {
@@ -313,7 +313,7 @@ namespace IntelligentPlant.BackgroundTasks.Tests {
 
                 using (var parentActivity = activitySource.StartActivity("Parent")) {
                     var workItem = svc.QueueBackgroundWorkItem(async ct => {
-                        using (activitySource.StartActivity(TestContext.TestName)) {
+                        using (activitySource.StartActivity(TestContext.TestName!)) {
                             try {
                                 await Task.Yield();
                                 Assert.AreEqual(TestContext.TestName, Activity.Current?.DisplayName);
@@ -358,7 +358,7 @@ namespace IntelligentPlant.BackgroundTasks.Tests {
                 SampleUsingParentId = (ref ActivityCreationOptions<string> activityOptions) => ActivitySamplingResult.AllData,
                 Sample = (ref ActivityCreationOptions<ActivityContext> activityOptions) => ActivitySamplingResult.AllData
             })
-            using (var activitySource = new ActivitySource(TestContext.TestName))
+            using (var activitySource = new ActivitySource(TestContext.TestName!))
             using (var svc = ActivatorUtilities.CreateInstance<DefaultBackgroundTaskService>(s_serviceProvider, options))
             using (var semaphore = new SemaphoreSlim(0))
             using (var ctSource = new CancellationTokenSource()) {
@@ -366,7 +366,7 @@ namespace IntelligentPlant.BackgroundTasks.Tests {
 
                 using (var parentActivity = activitySource.StartActivity("Parent")) {
                     var workItem = svc.QueueBackgroundWorkItem(async ct => {
-                        using (activitySource.StartActivity(TestContext.TestName)) {
+                        using (activitySource.StartActivity(TestContext.TestName!)) {
                             try {
                                 await Task.Yield();
                                 Assert.AreEqual(TestContext.TestName, Activity.Current?.DisplayName);
@@ -492,6 +492,41 @@ namespace IntelligentPlant.BackgroundTasks.Tests {
                 Assert.AreEqual(0, value);
 
                 ctSource.Cancel();
+            }
+        }
+
+
+        [TestMethod]
+        public async Task BackgroundWorkItemThatIsCancelledWhileQueuedShouldExecute() {
+            try {
+                AppContext.SetSwitch(BackgroundTaskService.InvokeCancelledWorkItemsSwitchName, true);
+
+                var options = new BackgroundTaskServiceOptions() {
+                    AllowWorkItemRegistrationWhileStopped = true,
+                };
+
+                using (var svc = ActivatorUtilities.CreateInstance<DefaultBackgroundTaskService>(s_serviceProvider, options))
+                using (var ctSource = new CancellationTokenSource()) {
+                    var value = 0;
+
+                    var workItem = new BackgroundWorkItem(async ct => {
+                        await Task.Yield();
+                        value = 1;
+                    });
+                    workItem.Cancel();
+
+                    svc.QueueBackgroundWorkItem(workItem);
+
+                    _ = svc.RunAsync(ctSource.Token);
+
+                    await workItem.Task;
+                    Assert.AreEqual(1, value);
+
+                    ctSource.Cancel();
+                }
+            }
+            finally {
+                AppContext.SetSwitch(BackgroundTaskService.InvokeCancelledWorkItemsSwitchName, false);
             }
         }
 


### PR DESCRIPTION
This PR adds support for explicit cancellation of work items via a new `BackgroundWorkItem.Cancel()` method.

Cancellation relies on a disposable `CancellationTokenSource` under the hood. To allow the disposable pattern to be correctly implemented, the `BackgroundWorkItem` struct is no longer `readonly` to allow its private `_disposed` field to be updated.

If `Cancel()` is called on a work item or any of its associated cancellation tokens fire before it gets to the front of the background task service's queue, the work item's delegate will not be called. This is a **breaking change**. The old behaviour can be restored by setting the `IntelligentPlant.BackgroundTasks.BackgroundTaskService.InvokeCancelledWorkItems` flag in `AppContext` to `true`.

The PR also adds `BeforeWorkItemStarted` and `AfterWorkItemCompleted` events that are invoked immediately before and immediately after running a work item delegate.